### PR TITLE
Fix bp_send_to_eid to handle binary payloads correctly using sdr_malloc and sdr_write

### DIFF
--- a/bp_socket/bp_genl.c
+++ b/bp_socket/bp_genl.c
@@ -3,22 +3,21 @@
 #include "af_bp.h"
 #include <net/genetlink.h>
 
-static struct genl_ops genl_ops[] = {
-	// {
-	// 	.cmd = BP_GENL_CMD_SEND_BUNDLE,
-	// 	.flags = GENL_ADMIN_PERM,
-	// 	.policy = nla_policy,
-	// 	.doit = fail_doit,
-	// 	.dumpit = NULL,
-	// },
-	{
-	    .cmd = BP_GENL_CMD_DELIVER_BUNDLE,
-	    .flags = GENL_ADMIN_PERM,
-	    .policy = nla_policy,
-	    .doit = deliver_bundle_doit,
-	    .dumpit = NULL,
-	}
+static const struct nla_policy nla_policy[BP_GENL_A_MAX + 1] = {
+	[BP_GENL_A_UNSPEC] = { .type = NLA_UNSPEC },
+	[BP_GENL_A_SOCKID] = { .type = NLA_U64 },
+	[BP_GENL_A_NODE_ID] = { .type = NLA_U32 },
+	[BP_GENL_A_SERVICE_ID] = { .type = NLA_U32 },
+	[BP_GENL_A_PAYLOAD] = { .type = NLA_BINARY },
 };
+
+static struct genl_ops genl_ops[] = { {
+    .cmd = BP_GENL_CMD_DELIVER_BUNDLE,
+    .flags = GENL_ADMIN_PERM,
+    .policy = nla_policy,
+    .doit = deliver_bundle_doit,
+    .dumpit = NULL,
+} };
 
 /* Multicast groups for our family */
 static const struct genl_multicast_group genl_mcgrps[] = {

--- a/daemon/bp_genl_handlers.c
+++ b/daemon/bp_genl_handlers.c
@@ -92,7 +92,7 @@ int handle_deliver_bundle(struct thread_args *args) {
     void *hdr = genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, args->netlink_family, 0, 0,
                             BP_GENL_CMD_DELIVER_BUNDLE, BP_GENL_VERSION);
     if (!hdr || nla_put_u32(msg, BP_GENL_A_SERVICE_ID, args->service_id) < 0 ||
-        nla_put_string(msg, BP_GENL_A_PAYLOAD, payload) < 0) {
+        nla_put(msg, BP_GENL_A_PAYLOAD, strlen(payload) + 1, payload) < 0) {
         log_error("DELIVER_BUNDLE: Failed to construct Netlink reply");
         nlmsg_free(msg);
         free(payload);

--- a/include/bp_socket.h
+++ b/include/bp_socket.h
@@ -5,8 +5,8 @@
 #include <linux/socket.h>
 #include <linux/types.h>
 #else
-#include <sys/socket.h>
 #include <stdint.h>
+#include <sys/socket.h>
 #endif
 
 #define AF_BP 28
@@ -36,18 +36,6 @@ enum bp_genl_cmds {
 };
 
 #define BP_GENL_CMD_MAX (__BP_GENL_CMD_MAX - 1)
-
-#ifdef __KERNEL__
-#include <net/genetlink.h>
-
-static const struct nla_policy nla_policy[BP_GENL_A_MAX + 1] = {
-    [BP_GENL_A_UNSPEC] = {.type = NLA_UNSPEC},
-    [BP_GENL_A_SOCKID] = {.type = NLA_U64},
-    [BP_GENL_A_NODE_ID] = {.type = NLA_U32},
-    [BP_GENL_A_SERVICE_ID] = {.type = NLA_U32},
-    [BP_GENL_A_PAYLOAD] = {.type = NLA_NUL_STRING},
-};
-#endif
 
 typedef enum bp_scheme {
   BP_SCHEME_IPN = 1,


### PR DESCRIPTION
## Summary

This PR fixes the way `bp_send_to_eid()` handles payload storage to ensure that binary data is transmitted correctly. Previously, the function used `sdr_string_create()`, which expected null-terminated strings and was incompatible with arbitrary binary payloads (e.g., serialized Protobuf). This caused truncation or data corruption.

## Changes

- Replaced `sdr_string_create()` with `sdr_malloc()` and `sdr_write()` to allocate and write the payload buffer explicitly.
- Renamed the `eid` parameter to `destEid` for clarity and consistency.
- Improved error messages to make failures more explicit (e.g., `sdr_malloc failed`, `zco_create failed`, `bp_send failed`).
- Removed redundant duplicate checks and logs.
- Preserved compatibility with existing calling code.

## Motivation

This change is necessary to support sending arbitrary binary payloads over BP sockets, such as Protobuf-encoded messages or compressed data. Using `sdr_string_create()` silently truncated buffers containing embedded null bytes, leading to incorrect bundle content.

## How to Test

- Use `bp_send_to_eid()` to send a binary payload containing null bytes.
- Confirm on the receiving side that the data is received intact.
- Check that error logs are clear when allocations fail.
